### PR TITLE
:bug: fix contributors query

### DIFF
--- a/src/queries.js
+++ b/src/queries.js
@@ -30,7 +30,13 @@ async function getRepositoryContributors(owner, repository) {
       `https://api.github.com/repos/${owner}/${repository}/stats/contributors?access_token=${githubToken}`,
       { headers: { 'User-Agent': githubId } },
     )
-    return res.data || []
+    if (!res.ok) {
+      throw res
+    }
+    if (res.status === 204) {
+      return []
+    }
+    return res.json()
   } catch (e) {
     console.log(e)
     process.exit(0)


### PR DESCRIPTION
This query does not currently work (I mean that is always returns an empty array) because responses returned by `fetch` do not have a field called `data`. This fixes the problem.