### PR TITLE
:sparkles: Enable passing multiple organizations to CLI

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -29,6 +29,22 @@ async function* generateOrganizationData(githubOrganizations) {
   members = filterNonUniqueBy(members, (a, b) => a.login === b.login)
   yield { type: MEMBERS_LOADED, value: members }
 
+  for (githubOrganization of githubOrganizations) {
+    const organizationRepositories = await getRepositoriesByOrganization(
+      githubOrganization,
+    )
+    const organization = {
+      name: githubOrganization,
+      members: membersByOrganisation[githubOrganization],
+      repositories: organizationRepositories,
+    }
+    yield {
+      type: ORGANIZATION_LOADED,
+      value: organization,
+      name: githubOrganization,
+    }
+  }
+
   for (member of members) {
     yield { type: START_ENHANCING_MEMBER, value: member.login }
 
@@ -56,22 +72,6 @@ async function* generateOrganizationData(githubOrganizations) {
     yield {
       type: ENHANCING_MEMBER_DONE,
       value: { ...member, repositories, contributionsCollection },
-    }
-  }
-
-  for (githubOrganization of githubOrganizations) {
-    const organizationRepositories = await getRepositoriesByOrganization(
-      githubOrganization,
-    )
-    const organization = {
-      name: githubOrganization,
-      members: membersByOrganisation[githubOrganization],
-      repositories: organizationRepositories,
-    }
-    yield {
-      type: ORGANIZATION_LOADED,
-      value: organization,
-      name: githubOrganization,
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -28,14 +28,14 @@ require('yargs')
       },
     },
     async function(argv) {
-      const githubOrganization = argv.organization
+      const githubOrganizations = !Array.isArray(argv.organization) ? [argv.organization] : argv.organization
       const githubId = process.env.GITHUB_ID
       const githubToken = process.env.GITHUB_OAUTH
 
       await createDataFolder()
 
-      let bar
-      const generator = generateOrganizationData(githubOrganization)
+      let bar 
+      const generator = generateOrganizationData(githubOrganizations)
 
       for await (const event of generator) {
         switch (event.type) {
@@ -57,7 +57,7 @@ require('yargs')
             writeMember(event.value)
             break
           case ORGANIZATION_LOADED:
-            writeOrganization(event.value)
+            writeOrganization(event.name, event.value)
             break
         }
       }

--- a/src/stats.js
+++ b/src/stats.js
@@ -10,18 +10,25 @@
   const generateFile = !!process.argv[2]
   const stats = {}
 
-  // Get the Gihub organization based on the .env values or the organization.json 
+  // Get the Gihub organization based on the .env values or the organization.json
   if (process.env.GITHUB_ORGA) {
     stats.organization = process.env.GITHUB_ORGA
   } else {
     const firstOrganizationFile = fs.readdirSync(organizationsFolder)[0]
     console.log(path.join(organizationsFolder, firstOrganizationFile))
-    stats.organization = JSON.parse(fs.readFileSync(path.join(organizationsFolder, firstOrganizationFile)))[0].owner.login
+    stats.organization = JSON.parse(
+      fs.readFileSync(path.join(organizationsFolder, firstOrganizationFile)),
+    )[0].owner.login
   }
 
-  const members = fs.readdirSync(path.join(__dirname, dataFolder))
-    .filter(file => !['members.json', 'organizations', 'stats.json'].includes(file))
-    .map(file => JSON.parse(fs.readFileSync(path.join(__dirname, dataFolder, file))))
+  const members = fs
+    .readdirSync(path.join(__dirname, dataFolder))
+    .filter(
+      file => !['members.json', 'organizations', 'stats.json'].includes(file),
+    )
+    .map(file =>
+      JSON.parse(fs.readFileSync(path.join(__dirname, dataFolder, file))),
+    )
   stats.totalMembers = members.length
 
   const membersWithRepositories = members.filter(
@@ -71,10 +78,18 @@
     .slice(0, 10)
     .map(([repo, count]) => ({ repo, count }))
 
-  const organizationRepositories = fs.readdirSync(organizationsFolder)
-    .map(file => JSON.parse(fs.readFileSync(path.join(__dirname, dataFolder, 'organizations', file))))
+  const organizationRepositories = fs
+    .readdirSync(organizationsFolder)
+    .map(file =>
+      JSON.parse(
+        fs.readFileSync(
+          path.join(__dirname, dataFolder, 'organizations', file),
+        ),
+      ),
+    )
+    .map(organization => organization.repositories)
     .flatMap(repositories => repositories)
-    
+
   stats.totalOrganizationRepositories = organizationRepositories.length
   stats.topOrganizationRepositories = organizationRepositories
     .reduce((acc, next) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,6 +20,7 @@ async function createDataFolder() {
   const folderPath = path.join(__dirname, rootDir)
   const alreadyExists = await existsAsync(folderPath)
   if (!alreadyExists) return mkdirAsync(folderPath)
+    .then(() => mkdirAsync(path.join(folderPath, 'organizations')))
 }
 
 async function writeMember(member) {
@@ -38,9 +39,9 @@ async function writeMembers(members) {
   return members
 }
 
-async function writeOrganization(organization) {
+async function writeOrganization(name, organization) {
   await writeFileAsync(
-    path.join(__dirname, rootDir, 'organization.json'),
+    path.join(__dirname, rootDir, 'organizations', `${name}.json`),
     prettyJson(organization),
   )
   return organization


### PR DESCRIPTION
Usage:

```sh
node src/index.js -o Zenika -o zenika-open-source
```

@hgwood I finished it, finally!

What changed:

There is an `organizations` folder in `data` with a file for each organization. All members are in `data`. 

Questionning:

Maybe we should store the membership of a member to an organization? I could store it in the file of an organization?